### PR TITLE
BUGFIX: enable service on each run

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -40,6 +40,7 @@ class ossec::client(
 		enable    => true,
 		hasstatus => $ossec::common::servicehasstatus,
 		pattern   => $ossec::common::hidsagentservice,
+		provider  => $ossec::common::serviceprovider, #workaround. See bug https://tickets.puppetlabs.com/browse/PUP-5296
 		require   => Package[$ossec::common::hidsagentpackage],
 	  }
 

--- a/manifests/common.pp
+++ b/manifests/common.pp
@@ -11,7 +11,10 @@ class ossec::common ( $ossec_override_keyfile       = false, ) {
       case $::operatingsystemrelease {
         /^5/:    {$redhatversion='el5'}
         /^6/:    {$redhatversion='el6'}
-        /^7/:    {$redhatversion='el7'}
+        /^7/:    {
+          $redhatversion='el7'
+          $serviceprovider = 'redhat' #workaround. See bug https://tickets.puppetlabs.com/browse/PUP-5296
+        }
         default: { }
       }
 	    package { 'inotify-tools':


### PR DESCRIPTION
Due to a bug in Puppet (https://tickets.puppetlabs.com/browse/PUP-5296), i implemented the recommended work around so that puppet doesn't try to enable the service on every run even though it is allready enabled. Bug is fixed in next puppet release (4.5.0, unknown release date)