### PR TITLE
FIX: logrotate module name corrected

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -113,7 +113,7 @@ class ossec::client(
     }
 
     #upload and compile custom selinux module for logrotate on the ossec.log file
-    selinux::module {'ossec-logrotate':
+    selinux::module {'ossec_logrotate':
         source => 'puppet:///modules/ossec/ossec-logrotate.te',
     }
 


### PR DESCRIPTION
Module name was with minus sign in puppet code and with underscore in .te file. Because of this, puppet applied it on every run. This fixes it.