### PR TITLE
Added profix 'local_' to module name

### DIFF
--- a/files/ossec-logrotate.te
+++ b/files/ossec-logrotate.te
@@ -1,4 +1,4 @@
-module ossec_logrotate 1.6.6;
+module local_ossec_logrotate 1.6.6;
 
 require {
         type var_t;


### PR DESCRIPTION
Selinux puppet module uses a prefix to store the module files. The new selinux policy (el 7.3) uses the name of the file to check the module name. The old one didn't. With this fix, the names match again.