### PR TITLE
CORE-541 - Removed include of mysql-client in main section

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -30,7 +30,6 @@ class ossec::server (
   $ossec_log_to_json                   = false,
 ) {
   include ossec::common
-  include mysql::client
 
   # install package
   case $::osfamily {


### PR DESCRIPTION
Is allready included in case statement. Was declared double.

Tested and ossec server in CORE-dev environment still works fine.